### PR TITLE
fast simulation

### DIFF
--- a/chapters/interactions-nonlinear.qmd
+++ b/chapters/interactions-nonlinear.qmd
@@ -24,6 +24,7 @@ library(embed)
 library(aorsf)
 library(patchwork)
 library(probably)
+library(foreach)
 library(doParallel)
 library(aspline)
 
@@ -1820,8 +1821,16 @@ make_data() %>%
 #| echo: false
 #| cache: true
 set.seed(614)
+
+sim_res <-
+  foreach(
+    poly_degree = rep(1:23, each = 5),
+    .combine = dplyr::bind_rows,
+    .packages = c("tidymodels")
+  ) %dopar% sim(poly_degree)
+
 sim_res <- 
-  map_dfr(rep(1:23, each = 50000), sim) %>%
+  sim_res %>%
   mutate(bias = truth - .pred) %>% 
   summarize(
     rmse = rmse_vec(y, .pred),

--- a/chapters/interactions-nonlinear.qmd
+++ b/chapters/interactions-nonlinear.qmd
@@ -1824,7 +1824,7 @@ set.seed(614)
 
 sim_res <-
   foreach(
-    poly_degree = rep(1:23, each = 5),
+    poly_degree = rep(1:23, each = 1000),
     .combine = dplyr::bind_rows,
     .packages = c("tidymodels")
   ) %dopar% sim(poly_degree)
@@ -1846,9 +1846,9 @@ sim_res <-
   )
 ```
 
-A linear model was estimated using ordinary least squares and a polynomial expansion for each simulated data set. The test set values were predicted, and the bias, variance, and root mean squared error statistics were computed. This was repeated 50,000 times for polynomial degrees ranging from one to twenty.  
+A linear model was estimated using ordinary least squares and a polynomial expansion for each simulated data set. The test set values were predicted, and the bias, variance, and root mean squared error statistics were computed. This was repeated 1,000 times for polynomial degrees ranging from one to twenty.  
 
-@fig-sim-results shows the average statistic values across model complexity (i.e., polynomial degree). A linear model performs poorly for the bias due to underfitting (as expected). In panel (a), adding more nonlinearity results in a substantial decrease in bias because the model fit is closer to the true equation. This improvement plateaus at a sixth-degree polynomial and stays low (nearly zero). The variance begins low; even though the linear model is ineffective, it is stable. Once additional terms are added, the variance of the model steadily increases then explodes around an 20<sup>th</sup> degree polynomial^[In this particular case, the variance becomes very large since the number of parameters is nearly the same as the number of training set points (`r nrow(make_data()) - 1`). This makes the underlying mathematical operation (matrix inversion) numerically unstable. Even so, it is the result of excessive model complexity.]. This shows the tradeoff; as the model becomes more complex, it fits the data better but eventually becomes unstable.
+@fig-sim-results shows the average statistic values across model complexity (i.e., polynomial degree). A linear model performs poorly for the bias due to underfitting (as expected). In panel (a), adding more nonlinearity results in a substantial decrease in bias because the model fit is closer to the true equation. This improvement plateaus at a sixth-degree polynomial and stays low (nearly zero). The variance begins low; even though the linear model is ineffective, it is stable. Once additional terms are added, the variance of the model steadily increases then explodes around a 20<sup>th</sup> degree polynomial^[In this particular case, the variance becomes very large since the number of parameters is nearly the same as the number of training set points (`r nrow(make_data()) - 1`). This makes the underlying mathematical operation (matrix inversion) numerically unstable. Even so, it is the result of excessive model complexity.]. This shows the tradeoff; as the model becomes more complex, it fits the data better but eventually becomes unstable.
 
 ```{r}
 #| label: fig-sim-results


### PR DESCRIPTION
The variance-bias simulation takes _forever_. The current results (50K sims): 

<img width="745" alt="image" src="https://github.com/user-attachments/assets/ca77e258-f09d-460c-b03f-3f6f4a5fe707">

versus 1K sims:

<img width="745" alt="image" src="https://github.com/user-attachments/assets/fc17283a-9238-46f8-936a-4afcd4f066a5">

Parallel processing gives it an additional 2-fold speed-up (16s locally)