### PR TITLE
remove recipes reference

### DIFF
--- a/R/_common.R
+++ b/R/_common.R
@@ -307,4 +307,12 @@ pval <- function(x, format = "html", max_zeros = 4) {
   res
 }
 
+# ------------------------------------------------------------------------------
+# From recipes::names0 and used in shinylive chunks
 
+names_zero_padded <- function(num, prefix = "x", call = rlang::caller_env()) {
+  rlang:::check_number_whole(num, min = 1, call = call)
+  ind <- format(seq_len(num))
+  ind <- gsub(" ", "0", ind)
+  paste0(prefix, ind)
+}

--- a/chapters/interactions-nonlinear.qmd
+++ b/chapters/interactions-nonlinear.qmd
@@ -903,7 +903,7 @@ server <- function(input, output, session) {
   
   expansion_to_tibble <- function(x, original, prefix = "term ") {
     cls <- class(x)[1]
-    nms <- recipes::names0(ncol(x), prefix)
+    nms <- names_zero_padded(ncol(x), prefix)
     colnames(x) <- nms
     x <- as_tibble(x)
     x$variable <- original
@@ -1108,7 +1108,7 @@ server <- function(input, output, session) {
   
   expansion_to_tibble <- function(x, original, prefix = "term ") {
     cls <- class(x)[1]
-    nms <- recipes::names0(ncol(x), prefix)
+    nms <- names_zero_padded(ncol(x), prefix)
     colnames(x) <- nms
     x <- as_tibble(x)
     x$variable <- original
@@ -1479,7 +1479,7 @@ trunc_power <-
   )
 
 two_knot_b <- splines2::bSpline(grid, knots = two_knots)
-colnames(two_knot_b) <- recipes::names0(ncol(two_knot_b), "basis_")
+colnames(two_knot_b) <- names_zero_padded(ncol(two_knot_b), "basis_")
 two_knot_b <- apply(as.matrix(two_knot_b), 2, scale_range)
 two_knot_b_df <- as_tibble(two_knot_b)
 two_knot_b_df$x <- grid
@@ -1613,7 +1613,7 @@ server <- function(input, output, session) {
   
   expansion_to_tibble <- function(x, original, prefix = "term ") {
     cls <- class(x)[1]
-    nms <- recipes::names0(ncol(x), prefix)
+    nms <- names_zero_padded(ncol(x), prefix)
     colnames(x) <- nms
     x <- as_tibble(x)
     x$variable <- original


### PR DESCRIPTION
For shinylive, we should load the fewest number of packages possible. One reason is that, if you move to a devel version, there is no wasm version of the package. 

This PR removes `recipes::names0()` and replaces it with a copy found in `R/_common.R`.

Pasting the error message below so that Future Max will find the answer when searching. From `quarto preview` in the command line: 

```

ℹ Loading metadata database
✔ Loading metadata database ... done

ℹ Loading metadata database
✔ Loading metadata database ... done

trying URL 'http://repo.r-wasm.org/bin/emscripten/contrib/4.4/recipes_1.2.1.tgz'
Content type 'application/x-tar' length 1221606 bytes (1.2 MB)
==================================================
downloaded 1.2 MB

trying URL 'http://repo.r-wasm.org/bin/emscripten/contrib/4.4/splines2_0.5.4.tgz'
Content type 'application/x-tar' length 1036102 bytes (1011 KB)
==================================================
downloaded 1011 KB

trying URL 'http://repo.r-wasm.org/bin/emscripten/contrib/4.4/class_7.3-23.tgz'
Content type 'application/x-tar' length 67102 bytes (65 KB)
==================================================
downloaded 65 KB

trying URL 'http://repo.r-wasm.org/bin/emscripten/contrib/4.4/clock_0.7.3.tgz'
Content type 'application/x-tar' length 1146405 bytes (1.1 MB)
==================================================
downloaded 1.1 MB

trying URL 'http://repo.r-wasm.org/bin/emscripten/contrib/4.4/data.table_1.17.0.tgz'
Content type 'application/x-tar' length 2168239 bytes (2.1 MB)
==================================================
downloaded 2.1 MB

Error in `get_github_wasm_assets()`:
! Can't find GitHub release for github::futureverse/future@HEAD
! Ensure a GitHub release exists for the package repository reference: "HEAD".
ℹ Alternatively, install a CRAN version of this package to use the default Wasm
  binary repository.
Caused by error in `gh::gh()`:
! GitHub API error (404): Not Found
✖ URL not found:
  <https://api.github.com/repos/futureverse/future/releases/tags/HEAD>
ℹ Read more at
  <https://docs.github.com/rest/releases/releases#get-a-release-by-tag-name>
``` 