### PR TITLE
Swapped references to the first and second principal components

### DIFF
--- a/chapters/embeddings.qmd
+++ b/chapters/embeddings.qmd
@@ -560,7 +560,7 @@ The loadings for the first four components of each linear embedding method as a 
 
 :::
 
-For the first component, wavelengths at the low ends of the spectrum have a relatively small impact that increases as you get to about 1,400 nm. At this point, the predictors have a constant effect on that component. The second PCA component is almost the opposite; it emphasizes the smaller wavelengths while predictors above 1,400 nm fluctuate around zero. The third and fourth components emphasize different areas of the spectrum and are generally different than zero.
+For the second component, wavelengths at the low ends of the spectrum have a relatively small impact that increases as you get to about 1,400 nm. At this point, the predictors have a constant effect on that component. The first PCA component is almost the opposite; it emphasizes the smaller wavelengths while predictors above 1,400 nm fluctuate around zero. The third and fourth components emphasize different areas of the spectrum and are generally different than zero.
 
 #### How to Incorporate PCA into the Model {.unnumbered}
 


### PR DESCRIPTION
For the text to match the figure, the first and second PCs need to be swapped?



Thanks for submitting an issue to the repository. 

***Important**:  

A merged PR will make you appear in the contributor list. It will, however, be considered a donation of your work to this project. You are still bound by the conditions of the license, meaning that you are **not considered an author, copyright holder, or owner** of the content once it has been merged in.

Submitting a PR will mean that you acknowledge that you understand that you give up any claims of authorship, ownership, or copyright (Max and Kjell excluded).

## Just a typo? 

That's great. The best thing you can do is make the change and check in the `qmd` file(s). Please don't include intermediate files (like HTML, md, etc). 

## A more substantial change? 

Please try to follow these guidelines: 

 - Discuss the change in an issue before submitting. 
 - Try to keep the scope of a specific PR as small as possible.
 - Try to change only the source files (e.g., `qmd`, `bib`, etc.).
 - Please stick to the R ecosystem. 
 - The edits cannot include exact code that is under another license (i.e., don't just copy/paste from R sources, etc.)
 - Respect the existing code formatting/linting (as heterogeneous as it is).

---

